### PR TITLE
feat: Update Lambda runtime to provided.al2023

### DIFF
--- a/templates/lambda.yaml
+++ b/templates/lambda.yaml
@@ -122,7 +122,7 @@ Resources:
       Code:
         S3Bucket: !FindInMap [RegionMap, !Ref 'AWS::Region', BucketName]
         S3Key: !Sub 'lambda/observer/arm64/${Version}.zip'
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !Ref MemorySize
       Timeout: !Ref Timeout
       ReservedConcurrentExecutions: !If


### PR DESCRIPTION
Upgrade Lambda functions in the CloudFormation templates from the deprecated `provided.al2` runtime to the recommended `provided.al2023` runtime, ensuring continued support and security updates beyond the July 2026 deprecation date.

